### PR TITLE
Improve Hex Literals w/ Tokenizer

### DIFF
--- a/src/cli/tokenizer/mod.rs
+++ b/src/cli/tokenizer/mod.rs
@@ -192,7 +192,7 @@ mod tests {
     fn tokenizer_parses_hex_literals() {
         let result = tokenize("X\'0A1A3F\' 12 X\'ZZZZZ\'");
         let expected = vec![
-            token(TokenTypes::HexLiteral, "X\'0A1A3F\'" , 0, 1),
+            token(TokenTypes::HexLiteral, "0A1A3F" , 0, 1),
             token(TokenTypes::IntLiteral, "12", 10, 1),
             token(TokenTypes::Error, "X\'Z", 13, 1),
             token(TokenTypes::Identifier, "ZZZZ", 16, 1),

--- a/src/cli/tokenizer/scanner.rs
+++ b/src/cli/tokenizer/scanner.rs
@@ -75,6 +75,21 @@ impl<'a> Scanner<'a> {
         };
     }
 
+    fn build_hex_literal_token(&mut self, start: usize, token_type: TokenTypes) -> Token<'a> {
+        return match token_type {
+            TokenTypes::HexLiteral => {
+                self.advance();
+                Token {
+                    token_type: token_type,
+                    value: &self.input[start+2..self.current-1],
+                    col_num: start-self.col_num,
+                    line_num: self.line_num,
+                }
+            }
+            _ => self.build_token(start, token_type)
+        }
+    }
+
     fn read_string(&mut self) -> TokenTypes {
         self.advance();
         while self.current_char() != '"' {
@@ -190,7 +205,7 @@ impl<'a> Scanner<'a> {
             }
             c if c == 'X' && self.peek_char() == '\'' => {
                 let token_type = self.read_hex_literal();
-                Some(self.build_token(start, token_type))
+                Some(self.build_hex_literal_token(start, token_type))
             }
             c if c.is_ascii_alphabetic() || c == '_' => {
                 let token_type = self.read_identifier(start);


### PR DESCRIPTION
Update tests and scanner for Hex Literals to go from `X'0AB1'` -> `0AB1`