### PR TITLE
Fix error messages to display the value instead of token type

### DIFF
--- a/src/cli/ast/mod.rs
+++ b/src/cli/ast/mod.rs
@@ -173,7 +173,7 @@ mod tests {
         ];
         let result = generate(tokens);
         assert!(result[0].is_err());
-        let expected = vec![Err("Error at line 1, column 0: Unexpected token type: Into".to_string())];
+        let expected = vec![Err("Error at line 1, column 0: Unexpected value: INTO".to_string())];
         assert_eq!(expected, result);
     }
 
@@ -242,7 +242,7 @@ mod tests {
         assert!(result[0].is_err());
         assert!(result[1].is_ok());
         let expected = vec![
-            Err("Error at line 1, column 0: Unexpected token type: SemiColon".to_string()),
+            Err("Error at line 1, column 0: Unexpected value: ;".to_string()),
             Ok(SqlStatement::InsertInto(InsertIntoStatement {
         
                 table_name: "users".to_string(),

--- a/src/cli/ast/parser.rs
+++ b/src/cli/ast/parser.rs
@@ -49,8 +49,8 @@ impl<'a> Parser<'a> {
         if self.current < self.tokens.len() {
             let token = &self.tokens[self.current];
             return format!(
-                "Error at line {:?}, column {:?}: Unexpected token type: {:?}",
-                token.line_num, token.col_num, token.token_type
+                "Error at line {:?}, column {:?}: Unexpected value: {}",
+                token.line_num, token.col_num, token.value.to_string()
             );
         } else {
             return "Error at end of input.".to_string();
@@ -101,7 +101,7 @@ mod tests {
         let tokens = vec![token(TokenTypes::Insert, "INSERT", 15, 3)];
         let parser = Parser::new(tokens);
         let result = parser.format_error();
-        assert_eq!(result, "Error at line 3, column 15: Unexpected token type: Insert");
+        assert_eq!(result, "Error at line 3, column 15: Unexpected value: INSERT");
     }
 
     pub struct MockStatementBuilder;
@@ -196,7 +196,7 @@ mod tests {
         let mut parser = Parser::new(tokens);
         let builder : &dyn StatementBuilder = &MockStatementBuilder;
         let result = parser.next_statement(builder);
-        let expected = Some(Err("Error at line 1, column 1: Unexpected token type: Identifier".to_string()));
+        let expected = Some(Err("Error at line 1, column 1: Unexpected value: users".to_string()));
         assert_eq!(result, expected);
     }
 }


### PR DESCRIPTION
Had an issue where error message was unclear was displaying:
`unexpected type IntLiteral` when the real issue was that the value was negative.