### PR TITLE
CI - Add step to run `cargo check` 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,20 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  check:
+    name: Rust Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust (latest stable)
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      
+      - name: Run checks
+        run: RUSTFLAGS="-D warnings" cargo check --verbose
+
   test:
     name: Rust Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Warnings will fail because of the `RUSTFLAGS="-D warnings"` env var.